### PR TITLE
Correct formatting of output

### DIFF
--- a/depenguinme.sh
+++ b/depenguinme.sh
@@ -311,7 +311,7 @@ fi
 	If you have difficulty connecting due to ssh key exchange error. then WAIT 2 MINUTES and try again.
 	SSH needs to come up correctly first.
 
-    Change to root to continue install with 'sudo su -'.
+	Change to root to continue install with 'sudo su -'.
 
 	Run 'zfsinstall -h' for install options, or provision with ansible scripts that cover installation.
 


### PR DESCRIPTION
`<<"-EOF"` only works with tabs, not spaces