### PR TITLE
Updates following testing PR33

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You must be logged in as root. Prepare file path or URL of SSH public key.
 Boot your server into rescue mode, then download and run the custom [mfsBSD-based installer](https://github.com/depenguin-me/depenguin-installer) for FreeBSD-13.1, with root-on-ZFS.
 
     wget https://depenguin.me/run.sh && chmod +x run.sh && \
-      ./run.sh [-d] [-r ram] [-m <url of own mfsbsd image> ] authorized_keys ...
+      ./run.sh [ -d ] [ -r ram ] [ -m <url of own mfsbsd image> ] authorized_keys ...
 
 The "-d" parameter will send the qemu process to the background.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Boot your server into rescue mode, then download and run the custom [mfsBSD-base
 
 The "-d" parameter will send the qemu process to the background.
 
-The "-r" parameter allows setting qemu memory for low memory systems, default is `8G` for `8GB`.
+The "-r" parameter allows setting qemu memory for low memory systems, default is `8G` for `8GiB`.
 
 The "-m" parameter allows using a custom mfsbsd ISO.
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ You must be logged in as root. Prepare file path or URL of SSH public key.
 Boot your server into rescue mode, then download and run the custom [mfsBSD-based installer](https://github.com/depenguin-me/depenguin-installer) for FreeBSD-13.1, with root-on-ZFS.
 
     wget https://depenguin.me/run.sh && chmod +x run.sh && \
-      ./run.sh [-d] [-m <url of own mfsbsd image> ] authorized_keys ...
+      ./run.sh [-d] [-r ram] [-m <url of own mfsbsd image> ] authorized_keys ...
 
 The "-d" parameter will send the qemu process to the background.
+
+The "-r" parameter allows setting qemu memory for low memory systems, default is `8G` for `8GB`.
+
+The "-m" parameter allows using a custom mfsbsd ISO.
 
 You must specify at least one authorized_keys source, both URLs and local files are supported.
 
@@ -49,3 +53,65 @@ To install FreeBSD-13.1 run the ```zfsinstall``` program with configuration para
 ##### Mirror disks ada0 and ada1
 
     zfsinstall -d ada0 -d ada1 -r mirror -s 4G -A -4 -c -p zroot
+
+### 5. Complete post-install actions
+Chroot to installed system.
+
+    chroot /mnt
+
+Create a group and username, set ssh keys.
+
+    pw groupadd YOUR-USER
+    pw useradd -m -n YOUR-USER -g YOUR-USER -G wheel -h - -c "your name"
+    cd /home/YOUR-USER
+    mkdir .ssh && chown YOUR-USER .ssh && chmod 700 .ssh
+    cd .ssh
+    vi authorized_keys    #paste in SSH pubkeys
+    chown YOUR-USER authorized_keys && chmod 600 authorized_keys
+    cd
+
+Configure `/etc/rc.conf` for hostname, networking, SSH server.
+
+A configuration suitable for Hetzner is listed below. Adapt to your settings:
+
+    vi /etc/rc.conf
+    
+    hostname="yourhostname"
+    ifconfig_igb0_name="untrusted"
+    ifconfig_untrusted="up"
+    ifconfig_untrusted_ipv6="up"
+    ifconfig_untrusted_aliases="inet 1.2.3.4/32 inet6 1234::123:123:1234::2/64"
+    ipv6_activate_all_interfaces="YES"
+    static_routes="gateway default"
+    route_gateway="-host 6.7.8.9 -interface untrusted"
+    route_default="default 6.7.8.9"
+    ipv6_defaultrouter="fe80::1%untrusted"
+    sshd_enable="YES"
+    zfs_enable="YES"
+
+Configure `/etc/resolv.conf` for DNS servers. Hetzner's are used in this example:
+
+    vi /etc/resolv.conf
+    
+    search YOURDOMAIN
+    nameserver 185.12.64.1
+    nameserver 185.12.64.2
+    nameserver 2a01:4ff:ff00::add:1
+    nameserver 2a01:4ff:ff00::add:2
+
+### 6. Reboot
+Exit the chroot environment with `ctrl-d`. 
+
+Switch to the rescue console session and press `ctrl-c` to end qemu. Then type `reboot`. 
+
+### 7. Connect to your new server
+After a few minutes to boot up, connect to your server via SSH:
+
+    ssh YOUR-USER@ip-address
+
+Check DNS is available and then perform initial system configuration such as:
+
+    freebsd-update fetch
+    freebsd-update install
+
+End

--- a/SUPPORTED-SERVERS.md
+++ b/SUPPORTED-SERVERS.md
@@ -7,7 +7,7 @@ This is a list of confirmed working, or not working, dedicated server systems.
 * Hetzner PX62-NVMe (v0.0.4, 2022-08-01)
 
 ### Full installation success
-* add
+* Hetzner AX41 (v0.0.6, 2022-08-10)
 
 ## NOT WORKING
 * add

--- a/depenguinme.sh
+++ b/depenguinme.sh
@@ -119,6 +119,7 @@ done
 apt-get update
 apt-get install -y mkisofs
 apt-get install -y qemu
+apt-get install -y qemu-system-x86
 
 # vars, do not adjust unless you know what you're doing for this script
 QEMUBASE="/tmp/depenguinme"


### PR DESCRIPTION
test passes fine with flag to set 2G qemu ram

missing command `qemu-system-X86_64` on a freshly installed ubuntu 20.04.4 host. (local test box)

added useful documentation currently missing