### PR TITLE
Add IPv6 support

### DIFF
--- a/depenguinme.sh
+++ b/depenguinme.sh
@@ -3,7 +3,7 @@
 # depenguinme.sh
 
 # please bump version on change
-VERSION="v0.0.9"
+VERSION="v0.0.10"
 
 # v0.0.1  2022-07-28  bretton depenguin.me
 #  this is a proof of concept with parts to be further developed
@@ -20,17 +20,17 @@ VERSION="v0.0.9"
 #  add options
 #  some cleanup
 #
-# v0.0.5 2022-08-03 various artists
+# v0.0.5  2022-08-03 various artists
 #
-# v0.0.6 2022-08-10 bretton depenguin.me
+# v0.0.6  2022-08-10 bretton depenguin.me
 #  Bump qemu memory in options from 1GB to 8GB so tmpfs is large
 #  enough to download freebsd install files
 #  Add note about sudo to root before install
 #
-# v0.0.7 2022-08-11 grembo depenguin.me
+# v0.0.7  2022-08-11 grembo depenguin.me
 #  Only install dependencies if not found
 #
-# v0.0.8 2022-08-11 bretton depenguin.me
+# v0.0.8  2022-08-11 bretton depenguin.me
 #  Remove unnecessary exported variables
 #  migrate historical context info from script to changelog
 #   2022-07-28
@@ -46,8 +46,11 @@ VERSION="v0.0.9"
 #   - https://support.org.ua/Soft/vKVM/orig/uefi.tar.gz
 #   - https://depenguin.me/files/uefi.tar.gz
 #
-# v0.0.9 2022-08-13 bretton depenguin.me
+# v0.0.9  2022-08-13 bretton depenguin.me
 #  README updates, switch to unattended bsdinstall process over zfsinstall
+#
+# v0.0.10 2022-08-23 grembo depenguin.me
+#  Add IPv6 support, add dependency for kvm-ok, enable qemu monitor socket
 
 # this script must be run as root
 if [ "$EUID" -ne 0 ]; then


### PR DESCRIPTION
This aims to detect an IPv6 only system and does what's necessary to
allow accessing mfsBSD.

Also:
- add missing dependency on kvm-ok
- add monitor socket to qemu (useful for debugging)

This addresses #10, which I can test for a full install, once this and https://github.com/depenguin-me/depenguin-builder/pull/9 landed.